### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ This GitHub Action allows you to super easily setup a DynamoDB Local instance wi
 
 ```yml
 - name: Setup DynamoDB Local
-  uses: rrainn/dynamodb-actions@v1.0.1
+  uses: rrainn/dynamodb-action@v1.0.1
 ```


### PR DESCRIPTION
Typo in the README.md

rrainn/dynamodb-actions@v1.0.1  -> . rrain/dynamodb-action@v1.0.1