### PR TITLE
Add `version` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Below is the default commands and settings for this action. For any properties t
     sharedDb: # undefined by default
     delayTransientStatuses: # undefined by default
     optimizeDbBeforeStartup: # undefined by default
+    version: # "latest" by default
     port: 8000
     cors: '*'
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'The port that DynamoDB should run on. Default: 8000'
     required: false
     default: '8000'
+  version:
+    description: 'The Docker image version'
+    required: false
+    default: 'latest'
   cors:
     description: 'The cors settings that should be used. Default: *'
     required: false

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-const settings = ["port", "dbPath", "sharedDb", "cors", "delayTransientStatuses", "optimizeDbBeforeStartup"].reduce((obj, key) => {
+const settings = ["port", "dbPath", "sharedDb", "cors", "delayTransientStatuses", "optimizeDbBeforeStartup", "version"].reduce((obj, key) => {
 	obj[key] = core.getInput(key);
 	return obj;
 }, {});
@@ -14,5 +14,5 @@ const settings = ["port", "dbPath", "sharedDb", "cors", "delayTransientStatuses"
 		settings.delayTransientStatuses ? `-delayTransientStatuses` : null,
 		settings.optimizeDbBeforeStartup ? `-optimizeDbBeforeStartup` : null
 	].filter((a) => Boolean(a)).join(" ");
-	await exec.exec(`sudo docker run --name dynamodb -d -p ${settings.port}:${settings.port} amazon/dynamodb-local -jar DynamoDBLocal.jar -port ${settings.port}${extraArguments ? ` ${extraArguments}` : ""}`);
+	await exec.exec(`sudo docker run --name dynamodb -d -p ${settings.port}:${settings.port} amazon/dynamodb-local:${settings.version} -jar DynamoDBLocal.jar -port ${settings.port}${extraArguments ? ` ${extraArguments}` : ""}`);
 })();


### PR DESCRIPTION
Adds new `version` option, that allows specifying the version of the `amazon/dynamodb-local` Docker image to use. Falls back to `latest`, keeping backwards compatibility.

Solves https://github.com/rrainn/dynamodb-action/issues/8